### PR TITLE
fix(registry): resolve infinite loop when calling Repositories()

### DIFF
--- a/registry/repositories.go
+++ b/registry/repositories.go
@@ -17,7 +17,10 @@ func (registry *Registry) Repositories() ([]string, error) {
 		// Sometimes only the path is returned instead of the full URL.
 		// If that's the case, then prepend the scheme and host to the path.
 		if strings.HasPrefix(url, "/") {
-			url = registry.url(url)
+			// Do not use registry.url(), as there may be a % which will not work well with
+			// fmt.Sprintf.
+			// Instead, just use regular string concatenation.
+			url = registry.URL + url
 		}
 		switch err {
 		case ErrNoMorePages:


### PR DESCRIPTION
Tested this with a local main.go:

```
// This is for testing purposes, only.

package main

import (
	"log"

	"github.com/heroku/docker-registry-client/registry"
)

func main() {
	user := "TODO"
	pass := "TODO"
	r, err := registry.New("https://quay.io", user, pass)
	if err != nil {
		log.Fatal(err)
	}

	repos, err := r.Repositories()
	if err != nil {
		log.Fatal(err)
	}

	log.Println(repos)
}
```